### PR TITLE
Setup portal_language correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,39 @@ Full ZCML example:
     </configure>
 
 
+Setting the language
+~~~~~~~~~~~~~~~~~~~~
+
+When installing a Plone site with the default add-site view, the language
+is set in the ``Products.CMFPlone:plone-content``, which also creates example content.
+This makes it hard to not create example content but setup the language correctly.
+
+To solve this issue ``ftw.inflator`` provides a ``ftw.inflator:setup-language`` generic
+setup profile, meant to be used while setting up a bundle.
+You can add it to the list of bundle profiles.
+Using it as a dependency (in ``metadata.xml``) is not recommended, since it is not meant
+to be used on a existing plone site.
+
+Example usage in bundle definition:
+
+.. code:: xml
+
+    <configure
+        xmlns="http://namespaces.zope.org/zope"
+        xmlns:inflator="http://namespaces.zope.org/inflator"
+        i18n_domain="my.package">
+
+        <include package="ftw.inflator" file="meta.zcml" />
+
+        <inflator:bundle
+            title="ftw.inflator example bundle one"
+            profiles="ftw.inflator:setup-language
+                      my.policy:default"
+            />
+
+    </configure>
+
+
 Content creation
 ----------------
 

--- a/ftw/inflator/configure.zcml
+++ b/ftw/inflator/configure.zcml
@@ -1,5 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:inflator="http://namespaces.zope.org/inflator"
     i18n_domain="ftw.inflator">
@@ -10,6 +11,21 @@
 
     <include package=".browser" />
     <include package=".creation" />
+
+    <genericsetup:registerProfile
+        name="setup-language"
+        title="ftw.inflator:setup-language"
+        directory="profiles/setup-language"
+        description="Sets the language seletected in the inflate wizard."
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:importStep
+        name="ftw.inflator.setuphandlers.inflator_setup_handlers"
+        title="ftw.inflator setup handlers"
+        description="ftw.inflator tasks such as setting up the language"
+        handler="ftw.inflator.setuphandlers.inflator_setup_handlers"
+        />
 
     <inflator:customize
         product="Plone"

--- a/ftw/inflator/profiles/setup-language/inflator-setup-language.txt
+++ b/ftw/inflator/profiles/setup-language/inflator-setup-language.txt
@@ -1,0 +1,2 @@
+Marker file for telling ftw.inflator to setup the language selected in the
+@@inflate view.

--- a/ftw/inflator/setuphandlers.py
+++ b/ftw/inflator/setuphandlers.py
@@ -1,0 +1,68 @@
+from Products.CMFCore.utils import getToolByName
+from plone.i18n.normalizer.interfaces import IURLNormalizer
+from zope.component import queryUtility
+from zope.i18n.locales import locales
+
+
+def setup_language(portal):
+    """When installing plone, the language is set when creating
+    example content.
+    If the content creation profile ``Products.CMFPlone:plone-content``
+    is not installed, the lanuage is not set up properly.
+
+    This setup handler allows to only setup the language but not
+    create example content by putting a ``inflator-setup-language.txt``
+    in a generic setup profile which is used on initialization.
+
+    The code of this function is copied from
+    ``Products.CMFPlone.setuphandlers.setupPortalContent``.
+    """
+    language = portal.Language()
+    parts = (language.split('-') + [None, None])[:3]
+    locale = locales.getLocale(*parts)
+    target_language = base_language = locale.id.language
+
+    # If we get a territory, we enable the combined language codes
+    use_combined = False
+    if locale.id.territory:
+        use_combined = True
+        target_language += '_' + locale.id.territory
+
+    # As we have a sensible language code set now, we disable the
+    # start neutral functionality
+    tool = getToolByName(portal, "portal_languages")
+
+    tool.manage_setLanguageSettings(language,
+        [language],
+        setUseCombinedLanguageCodes=use_combined,
+        startNeutral=False)
+
+    # Set the first day of the week, defaulting to Sunday, as the
+    # locale data doesn't provide a value for English. European
+    # languages / countries have an entry of Monday, though.
+    calendar = getToolByName(portal, "portal_calendar", None)
+    if calendar is not None:
+        first = 6
+        gregorian = locale.dates.calendars.get(u'gregorian', None)
+        if gregorian is not None:
+            first = gregorian.week.get('firstDay', None)
+            # on the locale object we have: mon : 1 ... sun : 7
+            # on the calendar tool we have: mon : 0 ... sun : 6
+            if first is not None:
+                first = first - 1
+
+        calendar.firstweekday = first
+
+    # Enable visible_ids for non-latin scripts
+
+    # See if we have an url normalizer
+    normalizer = queryUtility(IURLNormalizer, name=target_language)
+    if normalizer is None:
+        normalizer = queryUtility(IURLNormalizer, name=base_language)
+
+
+def inflator_setup_handlers(context):
+    site = context.getSite()
+
+    if context.readDataFile('inflator-setup-language.txt') is not None:
+        setup_language(site)

--- a/ftw/inflator/tests/configure.zcml
+++ b/ftw/inflator/tests/configure.zcml
@@ -18,7 +18,8 @@
     <inflator:bundle
         title="ftw.inflator example bundle one"
         description="an example bundle"
-        profiles="Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow
+        profiles="ftw.inflator:setup-language
+                  Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow
                   ftw.inflator.tests:foo_creation"
         base="Products.CMFPlone:plone"
         standard="True"

--- a/ftw/inflator/tests/test_inflate_view.py
+++ b/ftw/inflator/tests/test_inflate_view.py
@@ -1,3 +1,4 @@
+from Products.CMFCore.utils import getToolByName
 from ftw.inflator.testing import ZOPE_FUNCTIONAL_TESTING
 from plone.app.testing import SITE_OWNER_NAME, SITE_OWNER_PASSWORD
 from plone.testing.z2 import Browser
@@ -43,8 +44,13 @@ class TestInflateView(TestCase):
 
     def test_install_test_profile(self):
         self.browser.open('http://localhost/@@inflate')
+
+        self.browser.getControl(name='default_language').value = ['de']
         self.browser.getControl('Install').click()
         self.assertEqual(self.browser.url, 'http://localhost/platform')
 
         site = self.app.get('platform')
         self.assertTrue(site)
+
+        language_tool = getToolByName(site, 'portal_languages')
+        self.assertEqual(language_tool.getDefaultLanguage(), 'de')


### PR DESCRIPTION
When installing a Plone site with the default add-site view, the language
is set in the `Products.CMFPlone:plone-content`, which also creates example content.
This makes it hard to not create example content but setup the language correctly.

To solve this issue `ftw.inflator` provides a `ftw.inflator:setup-language` generic
setup profile, meant to be used while setting up a bundle.
You can add it to the list of bundle profiles.
Using it as a dependency (in `metadata.xml`) is not recommended, since it is not meant
to be used on a existing plone site.
