### PR TITLE
Fix patching order (ZMI)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Make sure that the Products.CMFPlone ZMI patches are applied
+  prior to our patches.
+  [jone]
+
 - Support UTF-8 encoded strings as value for :translate().
   [treinhard]
 

--- a/ftw/inflator/__init__.py
+++ b/ftw/inflator/__init__.py
@@ -1,6 +1,4 @@
-from ftw.inflator.patches import apply_patches
 from zope.i18nmessageid import MessageFactory
 
 
 _ = MessageFactory('ftw.inflator')
-apply_patches()

--- a/ftw/inflator/configure.zcml
+++ b/ftw/inflator/configure.zcml
@@ -5,12 +5,17 @@
     xmlns:inflator="http://namespaces.zope.org/inflator"
     i18n_domain="ftw.inflator">
 
+    <!-- it is important to include Products.CMFPlone, so that the
+         ZCMI patches are applied in the right order. -->
+    <include package="Products.CMFPlone" />
+
     <i18n:registerTranslations directory="locales" />
 
     <include file="meta.zcml" />
 
     <include package=".browser" />
     <include package=".creation" />
+    <include package=".patches" />
 
     <genericsetup:registerProfile
         name="setup-language"

--- a/ftw/inflator/patches/__init__.py
+++ b/ftw/inflator/patches/__init__.py
@@ -43,3 +43,5 @@ def patch_ZMI_button():
     main._v_cooked = main.cook()
 
     return True
+
+apply_patches()

--- a/ftw/inflator/patches/configure.zcml
+++ b/ftw/inflator/patches/configure.zcml
@@ -1,0 +1,12 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+    <!--
+         This ZCML is empty by intention.
+         Including this package automatically applies the
+         patches of the __init__ since it has to be imported.
+
+         This allows us to make sure that the patches are applied after
+         the underlying Products.CMFPlone patches.
+    -->
+
+</configure>


### PR DESCRIPTION
Make sure that the Products.CMFPlone ZMI patches are applied prior to our patches.

Hopefully fixes #5 
/cc @maethu 
