### PR TITLE
Fix unresolved generic setup import step dependencies.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix unresolved generic setup import step dependencies.
+  "languagetool" is only available when plone.app.multilingual is installed.
+  [jone]
 
 
 1.2 (2013-12-11)

--- a/ftw/inflator/creation/configure.zcml
+++ b/ftw/inflator/creation/configure.zcml
@@ -22,7 +22,8 @@
         handler="ftw.inflator.creation.setuphandler.content_creation">
         <depends name="typeinfo"/>
         <depends name="workflow"/>
-        <depends name="languagetool"/>
+        <depends name="languagetool"
+                 zcml:condition="installed plone.app.multilingual"/>
     </genericsetup:importStep>
 
     <transmogrifier:registerConfig

--- a/ftw/inflator/tests/test_multilingual_content_creation.py
+++ b/ftw/inflator/tests/test_multilingual_content_creation.py
@@ -50,3 +50,13 @@ class TestMultilingualContentCreation(TestCase):
         self.assertEquals(german_content,
                           manager.get_translation('de'),
                           'English and German content should be linked.')
+
+    def test_content_creation_import_step_depends_on_languagetool(self):
+        # The content creation import step needs to depend on the "languagetool"
+        # import step when plone.app.multilingual is installed.
+        # The "languagetool" import step is not Plone core.
+
+        setup_tool = getToolByName(self.portal, 'portal_setup')
+        import_step_name = 'ftw.inflator.content_creation'
+        metadata = setup_tool.getImportStepMetadata(import_step_name)
+        self.assertIn('languagetool', metadata.get('dependencies', ()))


### PR DESCRIPTION
Fixes:

```
WARNING GenericSetup There are unresolved or circular dependencies. Graphviz diagram ...
```

The import step "languagetool" is only available when p.a.multilingual is installed, which caused the unresolved dependencies warning in a non-multilingual installation.

/cc @deiferni 
