### PR TITLE
Add a section to resolve objects by their path.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -541,12 +541,36 @@ The UUID lookup helps you here:
               "_path": "foo",
               "_type": "MyType",
               "title": "Foo",
-              "relations": "resolveUUID::/bar"
+              "relations": "resolveUUID::bar"
           }
       ]
 
 Using the ``resolveUUID::path`` syntax the value is replaced with UUID of the
 object which has the ``path``.
+You can prefix the value with a `/` for making it relative to the site root,
+otherwise it is relative to the item it is defined in ("Foo" in the above
+example).
+
+
+Path Lookup
+~~~~~~~~~~~
+
+Sometimes you need to resolve an already created object by its path.
+The resolve-path section helps you here:
+
+.. code:: javascript
+
+
+      [
+          {
+              "_path": "foo",
+              "_type": "MyType",
+              "title": "Foo",
+              "relations": "resolvePath::bar"
+          }
+      ]
+
+Using the ``resolvePath::path`` syntax the value is replaced with the resolved object.
 You can prefix the value with a `/` for making it relative to the site root,
 otherwise it is relative to the item it is defined in ("Foo" in the above
 example).

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - Use ftw.profilehook instead of custom import steps (setuphandlers).
   [jone]
 
+- Add section to resolve objects by their path.
+  [deiferni]
+
 
 1.4 (2014-06-05)
 ----------------

--- a/ftw/inflator/creation/configure.zcml
+++ b/ftw/inflator/creation/configure.zcml
@@ -106,4 +106,9 @@
         component=".sections.local_roles.BlockLocalRoleInheritance"
         />
 
+    <utility
+        name="ftw.inflator.creation.resolvepath"
+        component=".sections.resolvepath.ResolvePath"
+        />
+
 </configure>

--- a/ftw/inflator/creation/content_creation.cfg
+++ b/ftw/inflator/creation/content_creation.cfg
@@ -9,6 +9,7 @@ pipeline =
     encode-id
     constructor
     resolveuuid
+    resolvepath
     schemaupdater
     dx_schemaupdater
     workflowupdater
@@ -56,6 +57,9 @@ blueprint = collective.transmogrifier.sections.constructor
 
 [resolveuuid]
 blueprint = ftw.inflator.creation.resolveuuid
+
+[resolvepath]
+blueprint = ftw.inflator.creation.resolvepath
 
 [schemaupdater]
 blueprint = plone.app.transmogrifier.atschemaupdater

--- a/ftw/inflator/creation/sections/resolvepath.py
+++ b/ftw/inflator/creation/sections/resolvepath.py
@@ -1,0 +1,50 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from collective.transmogrifier.utils import defaultMatcher
+from ftw.inflator.creation.sections.helpers import map_recursive
+from zope.interface import classProvides
+from zope.interface import implements
+
+
+class ResolvePath(object):
+
+    PREFIX = 'resolvePath::'
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.transmogrifier = transmogrifier
+        self.context = transmogrifier.context
+        self.previous = previous
+        self.pathkey = defaultMatcher(options, 'path-key', name, 'path')
+
+    def __iter__(self):
+        for item in self.previous:
+            yield map_recursive(
+                lambda value: value.startswith(self.PREFIX),
+                lambda value: self._resolve(item, value),
+                item)
+
+    def _resolve(self, item, value):
+        value = value.replace(self.PREFIX, '', 1)
+
+        return self._get_object_by_path(item, value)
+
+    def _get_object_by_path(self, item, path):
+        if isinstance(path, unicode):
+            path = path.encode('utf-8')
+
+        path = path.rstrip('/')
+
+        if path.startswith('/'):
+            return self.context.unrestrictedTraverse(path.lstrip('/'))
+        else:
+            item_obj = self._get_obj(item)
+            return item_obj.unrestrictedTraverse(path)
+
+    def _get_obj(self, item):
+        path = item.get(self.pathkey(*item.keys())[0], None)
+        obj = self.context.unrestrictedTraverse(
+            path.encode('utf-8').lstrip('/'), None)
+        return obj

--- a/ftw/inflator/creation/sections/resolveuuid.py
+++ b/ftw/inflator/creation/sections/resolveuuid.py
@@ -1,53 +1,18 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
-from collective.transmogrifier.utils import defaultMatcher
-from ftw.inflator.creation.sections.helpers import map_recursive
+from ftw.inflator.creation.sections.resolvepath import ResolvePath
 from plone.uuid.interfaces import IUUID
 from zope.interface import classProvides
 from zope.interface import implements
 
 
-PREFIX = 'resolveUUID::'
+class ResolveUUID(ResolvePath):
 
-
-class ResolveUUID(object):
+    PREFIX = 'resolveUUID::'
 
     classProvides(ISectionBlueprint)
     implements(ISection)
 
-    def __init__(self, transmogrifier, name, options, previous):
-        self.transmogrifier = transmogrifier
-        self.context = transmogrifier.context
-        self.previous = previous
-        self.pathkey = defaultMatcher(options, 'path-key', name, 'path')
-
-    def __iter__(self):
-        for item in self.previous:
-            yield map_recursive(
-                lambda value: value.startswith(PREFIX),
-                lambda value: self._resolve(item, value),
-                item)
-
     def _resolve(self, item, value):
-        value = value.lstrip(PREFIX)
-
-        obj = self._get_object_by_path(item, value)
+        obj = super(ResolveUUID, self)._resolve(item, value)
         return IUUID(obj)
-
-    def _get_object_by_path(self, item, path):
-        if isinstance(path, unicode):
-            path = path.encode('utf-8')
-
-        path = path.rstrip('/')
-
-        if path.startswith('/'):
-            return self.context.unrestrictedTraverse(path.lstrip('/'))
-        else:
-            item_obj = self._get_obj(item)
-            return item_obj.unrestrictedTraverse(path)
-
-    def _get_obj(self, item):
-        path = item.get(self.pathkey(*item.keys())[0], None)
-        obj = self.context.unrestrictedTraverse(
-            path.encode('utf-8').lstrip('/'), None)
-        return obj

--- a/ftw/inflator/tests/interfaces.py
+++ b/ftw/inflator/tests/interfaces.py
@@ -1,5 +1,7 @@
 from plone.directives.form import Schema
+from plone.formwidget.contenttree import ObjPathSourceBinder
 from plone.namedfile.field import NamedImage
+from z3c.relationfield.schema import RelationChoice
 from zope.interface import Interface
 
 
@@ -11,4 +13,9 @@ class IFoo(Interface):
 class IExampleDxType(Schema):
     image = NamedImage(
         title=u'Image',
+        )
+
+    relation = RelationChoice(
+        title=u'Relation',
+        source=ObjPathSourceBinder(),
         )

--- a/ftw/inflator/tests/profiles/dx_creation/content_creation/01_dexterity.json
+++ b/ftw/inflator/tests/profiles/dx_creation/content_creation/01_dexterity.json
@@ -1,5 +1,9 @@
 [
   {
+    "_path": "target",
+    "_type": "ExampleDxType",
+    "title": "relation target"
+  }, {
     "_path": "my-dx",
     "_type": "ExampleDxType",
     "title": "My Dexterity Object",
@@ -28,8 +32,7 @@
         ]
     },
 
-    "image:file": "files/chuck-norris.jpg"
-
-
+    "image:file": "files/chuck-norris.jpg",
+    "relation":  "resolvePath::/target"
   }
 ]

--- a/ftw/inflator/tests/test_dx_content_creation.py
+++ b/ftw/inflator/tests/test_dx_content_creation.py
@@ -93,3 +93,8 @@ class TestDXContentCreation(TestCase):
         self.assertEqual(("Owner", "Contributor", "Editor",),
                          roles.get("admin"))
         self.assertEqual(("Editor",), roles.get("hans"))
+
+    def test_paths_are_resolved(self):
+        obj = self.portal.get('my-dx')
+        target = self.portal.get('target')
+        self.assertEqual(obj.relation, target)

--- a/sources.cfg
+++ b/sources.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends = http://kgs.4teamwork.ch/sources.cfg
+extensions = mr.developer
+
+auto-checkout =

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -2,6 +2,7 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
     http://good-py.appspot.com/release/dexterity/1.0-next
+    sources.cfg
     versions.cfg
 
 package-name = ftw.inflator

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -2,5 +2,6 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
     versions.cfg
+    sources.cfg
 
 package-name = ftw.inflator

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -2,5 +2,6 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
     versions.cfg
+    sources.cfg
 
 package-name = ftw.inflator


### PR DESCRIPTION
We want to inflate dexterity content that uses `z3c.relationfield.schema`-`RelationList`/`RelationChoice` in combination with `plone.app.intid`.

We already added converters to `transmogrify.dexterity` that create `RelationValue` objects for plone objects. In combination with above pull-request it is necessary to resolve objects by their path while inflating.