### PR TITLE
Add export functionality for exporting content types in content creation format.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ Features
 - A generic setup site creation import step which can be used in the bundles
   for creating initial content. It can be used without using the setup wizard
   and bundle system.
+- Export of content for creating a content creation profile.
 
 
 Installation
@@ -599,6 +600,18 @@ You can configure local roles and block local as following:
       ]
 
 For details, see: https://github.com/collective/collective.blueprint.jsonmigrator
+
+
+Export
+------
+
+The ``ftw.inflator.export:default`` profile adds an entry to the Plone control panel,
+allowing to export the current content as ZIP with JSON-files.
+The ``content_creation`` folder in the ZIP can be placed in a Generic Setup profile,
+which will then create the content when installed.
+
+The export may be incomplete, especially for types with additional features, such as
+storing data in the annotations.
 
 
 Links

--- a/development.cfg
+++ b/development.cfg
@@ -2,3 +2,7 @@
 extends =
     test-plone-4.3.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+
+
+[instance]
+eggs += ftw.inflator [dexterity, export]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add export functionality for exporting content types in content creation format.
+  [jone]
 
 
 1.5 (2015-04-22)

--- a/ftw/inflator/configure.zcml
+++ b/ftw/inflator/configure.zcml
@@ -4,6 +4,7 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:inflator="http://namespaces.zope.org/inflator"
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.inflator">
 
     <!-- it is important to include Products.CMFPlone, so that the
@@ -13,11 +14,13 @@
 
     <i18n:registerTranslations directory="locales" />
 
+    <include file="features.zcml" />
     <include file="meta.zcml" />
 
     <include package=".browser" />
     <include package=".creation" />
     <include package=".patches" />
+    <include package=".export" zcml:condition="have inflator:export" />
 
     <genericsetup:registerProfile
         name="setup-language"

--- a/ftw/inflator/export/configure.zcml
+++ b/ftw/inflator/export/configure.zcml
@@ -1,0 +1,24 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="ftw.inflator">
+
+    <genericsetup:registerProfile
+        name="default"
+        title="ftw.inflator.export"
+        directory="profiles/default"
+        description="Export the site structure."
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <browser:page
+        name="inflator-export"
+        for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
+        class=".views.InflatorExport"
+        permission="cmf.ManagePortal"
+        template="templates/export-form.pt"
+        />
+
+</configure>

--- a/ftw/inflator/export/profiles/default/controlpanel.xml
+++ b/ftw/inflator/export/profiles/default/controlpanel.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<object name="portal_controlpanel" meta_type="Plone Control Panel Tool">
+
+    <configlet title="Inflator export"
+               action_id="inflator-export"
+               appId="ftw.inflator"
+               category="Products"
+               url_expr="string:${portal_url}/inflator-export"
+               condition_expr=""
+               visible="True">
+        <permission>Manage portal</permission>
+    </configlet>
+
+</object>

--- a/ftw/inflator/export/profiles/default/metadata.xml
+++ b/ftw/inflator/export/profiles/default/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+    <version>1000</version>
+</metadata>

--- a/ftw/inflator/export/templates/export-form.pt
+++ b/ftw/inflator/export/templates/export-form.pt
@@ -1,0 +1,43 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/prefs_main_template/macros/master"
+      i18n:domain="ftw.inflator">
+
+    <body>
+
+        <div metal:fill-slot="prefs_configlet_content">
+            <div class="documentContent" id="content">
+                <h1 class="documentFirstHeading">Inflator export</h1>
+
+                <a href=""
+                   class="link-parent"
+                   tal:attributes="href string:$portal_url/plone_control_panel"
+                   i18n:translate="label_up_to_plone_setup"
+                   i18n:domain="plone">
+                    Up to Site Setup
+                </a>
+
+                <form method="post"
+                      tal:attributes="action string:${here/absolute_url}/inflator-export">
+
+                    <p i18n:translate="export_warning">
+                        <b i18n:name="warning" i18n:translate="warning">Warning:</b>
+                        This exports the complete site structure.
+                        For big sites, this may take some time.
+                        The export produces a ZIP-file containing JSON-files,
+                        which can be used for inflator's content creation later.
+                    </p>
+
+                    <input type="submit" value="Export" name="submitted"
+                           i18n:attributes="value button_export" />
+
+                </form>
+
+            </div>
+        </div>
+
+    </body>
+</html>

--- a/ftw/inflator/export/views.py
+++ b/ftw/inflator/export/views.py
@@ -1,0 +1,94 @@
+from collections import defaultdict
+from datetime import datetime
+from ftw.jsondump.interfaces import IJSONRepresentation
+from ftw.zipexport.generation import ZipGenerator
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
+from StringIO import StringIO
+from zope.component import getMultiAdapter
+from ZPublisher.Iterators import filestream_iterator
+import json
+import os
+
+
+class InflatorExport(BrowserView):
+
+    def __call__(self):
+        if self.request.form.get('submitted'):
+            return self.export()
+        return super(InflatorExport, self).__call__()
+
+    def export(self):
+        with ZipGenerator() as generator:
+            self.build_section_files(generator)
+            return self.stream_for_downlaod(generator.generate())
+
+    def stream_for_downlaod(self, zipfile):
+        filename = 'content_creation-{0}.zip'.format(
+            datetime.now().strftime('%Y%m%d%H%M'))
+        self.request.response.setHeader(
+            "Content-Disposition",
+            'inline; filename="%s"' % filename.encode('utf-8'))
+        self.request.response.setHeader("Content-type", "application/zip")
+        self.request.response.setHeader(
+            "Content-Length",
+            os.stat(zipfile.name).st_size)
+        return filestream_iterator(zipfile.name, 'rb')
+
+    def build_section_files(self, generator):
+        for section_id, objects in self.get_objects_by_sections().items():
+            data = [self.get_data_for_object(obj, generator)
+                    for obj in objects]
+            path = u'content_creation/{0}.json'.format(
+                section_id.decode('utf-8'))
+            filedata = StringIO(json.dumps(data, sort_keys=True, indent=4))
+            generator.add_file(path, filedata)
+
+    def get_data_for_object(self, obj, generator):
+        locals()['__traceback_info__'] = obj
+        repr = getMultiAdapter((obj, self.request), IJSONRepresentation)
+
+        def file_callback(context, key, fieldname, data, filename,
+                          mimetype, jsondata):
+            if not data:
+                return
+
+            if not isinstance(filename, unicode):
+                filename = filename.decode('utf8')
+
+            filepath = 'files/{0}-{1}/{2}'.format(
+                '-'.join(obj.getPhysicalPath()[
+                        len(self.context.getPhysicalPath()):]),
+                fieldname,
+                filename).decode('utf-8')
+            generator.add_file(u'content_creation/' + filepath, StringIO(data))
+            jsondata['{0}:file'.format(key)] = filepath
+
+        return self.process_item(json.loads(repr.json(
+                    file_callback=file_callback)))
+
+    def get_objects_by_sections(self):
+        sections = defaultdict(list)
+
+        site_path = '/'.join(self.context.getPhysicalPath())
+        catalog = getToolByName(self.context, 'portal_catalog')
+        query = {'sort_on': 'path'}
+        brains = catalog.unrestrictedSearchResults(query)
+
+        for brain in brains:
+            section_id = brain.getPath().split('/')[site_path.count('/') + 1]
+            obj = self.context.unrestrictedTraverse(brain.getPath())
+            sections[section_id].append(obj)
+
+        return sections
+
+    def process_item(self, item):
+        item['_path'] = '/'.join(
+            item['_path'].split('/')[len(self.context.getPhysicalPath()):])
+
+        properties = {}
+        for name, value, type_ in item['_properties']:
+            properties[name] = [type_, value]
+        item['_properties'] = properties
+
+        return item

--- a/ftw/inflator/features.zcml
+++ b/ftw/inflator/features.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:meta="http://namespaces.zope.org/meta"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    i18n_domain="ftw.inflator">
+
+    <configure zcml:condition="installed ftw.jsondump">
+        <configure zcml:condition="installed ftw.zipexport">
+            <meta:provides feature="inflator:export" />
+        </configure>
+    </configure>
+
+</configure>

--- a/ftw/inflator/locales/de/LC_MESSAGES/ftw.inflator.po
+++ b/ftw/inflator/locales/de/LC_MESSAGES/ftw.inflator.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-02-01 16:26+0000\n"
+"POT-Creation-Date: 2015-05-28 13:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,17 +10,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
-#: ./ftw/inflator/browser/overview.pt:31
+#: ./ftw/inflator/browser/overview.pt:29
 msgid "${product} is up and running."
 msgstr "${product} läuft."
 
-#: ./ftw/inflator/browser/inflate.pt:145
+#: ./ftw/inflator/browser/inflate.pt:144
 msgid "Bundle"
 msgstr "Bundle"
 
-#: ./ftw/inflator/browser/views.py:88
+#: ./ftw/inflator/browser/views.py:66
 msgid "Create a new ${product} site"
 msgstr "${product} installieren"
 
@@ -28,26 +27,41 @@ msgstr "${product} installieren"
 msgid "Install ${product}"
 msgstr "${product} installieren"
 
-#: ./ftw/inflator/browser/inflate.pt:149
+#: ./ftw/inflator/browser/inflate.pt:148
 msgid "Select a ${product} bundle."
 msgstr "Wählen Sie ein ${product} bundle aus."
 
-#: ./ftw/inflator/browser/inflate.pt:175
+#: ./ftw/inflator/browser/inflate.pt:174
 msgid "There are no bundles defined. Please consult the ${documentation}."
 msgstr "Es konnten keine Bundle-Definitionen gefunden werden. Bitte konsultieren Sie die ${documentation}."
 
-#: ./ftw/inflator/browser/overview.pt:47
+#: ./ftw/inflator/browser/overview.pt:45
 msgid "View your ${product} site"
 msgstr "${product} öffnen"
 
-#: ./ftw/inflator/browser/overview.pt:76
+#: ./ftw/inflator/browser/overview.pt:74
 msgid "You have multiple ${product} sites:"
 msgstr "Sie haben mehrere ${product} installationen:"
 
-#: ./ftw/inflator/browser/overview.pt:122
+#: ./ftw/inflator/browser/overview.pt:120
 msgid "Your ${product} site has not been added yet:"
 msgstr "Sie haben noch keine ${product} installation:"
 
-#: ./ftw/inflator/browser/inflate.pt:175
+#. Default: "Export"
+#: ./ftw/inflator/export/templates/export-form.pt:34
+msgid "button_export"
+msgstr "Exportieren"
+
+#. Default: "${warning} This exports the complete site structure. For big sites, this may take some time. The export produces a ZIP-file containing JSON-files, which can be used for inflator's content creation later."
+#: ./ftw/inflator/export/templates/export-form.pt:27
+msgid "export_warning"
+msgstr "${warning} Diese exportiert alle Inhalte auf dieser Seite. Bei grossen Seite kann dies einige Minuten dauern. Der Export produzieren eine ZIP-Datei, welche JSON-Dateien im content_creation Format enthält."
+
+#: ./ftw/inflator/browser/inflate.pt:174
 msgid "ftw.inflator documentation"
 msgstr "ftw.inflator Dokumentation"
+
+#. Default: "Warning:"
+#: ./ftw/inflator/export/templates/export-form.pt:27
+msgid "warning"
+msgstr "Warnung:"

--- a/ftw/inflator/locales/ftw.inflator.pot
+++ b/ftw/inflator/locales/ftw.inflator.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-02-01 16:26+0000\n"
+"POT-Creation-Date: 2015-05-28 13:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,20 +12,17 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"Language-Code: en\n"
-"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: ftw.inflator\n"
 
-#: ./ftw/inflator/browser/overview.pt:31
+#: ./ftw/inflator/browser/overview.pt:29
 msgid "${product} is up and running."
 msgstr ""
 
-#: ./ftw/inflator/browser/inflate.pt:145
+#: ./ftw/inflator/browser/inflate.pt:144
 msgid "Bundle"
 msgstr ""
 
-#: ./ftw/inflator/browser/views.py:88
+#: ./ftw/inflator/browser/views.py:66
 msgid "Create a new ${product} site"
 msgstr ""
 
@@ -33,27 +30,43 @@ msgstr ""
 msgid "Install ${product}"
 msgstr ""
 
-#: ./ftw/inflator/browser/inflate.pt:149
+#: ./ftw/inflator/browser/inflate.pt:148
 msgid "Select a ${product} bundle."
 msgstr ""
 
-#: ./ftw/inflator/browser/inflate.pt:175
+#: ./ftw/inflator/browser/inflate.pt:174
 msgid "There are no bundles defined. Please consult the ${documentation}."
 msgstr ""
 
-#: ./ftw/inflator/browser/overview.pt:47
+#: ./ftw/inflator/browser/overview.pt:45
 msgid "View your ${product} site"
 msgstr ""
 
-#: ./ftw/inflator/browser/overview.pt:76
+#: ./ftw/inflator/browser/overview.pt:74
 msgid "You have multiple ${product} sites:"
 msgstr ""
 
-#: ./ftw/inflator/browser/overview.pt:122
+#: ./ftw/inflator/browser/overview.pt:120
 msgid "Your ${product} site has not been added yet:"
 msgstr ""
 
-#: ./ftw/inflator/browser/inflate.pt:175
+#. Default: "Export"
+#: ./ftw/inflator/export/templates/export-form.pt:34
+msgid "button_export"
+msgstr ""
+
+#. Default: "${warning} This exports the complete site structure. For big sites, this may take some time. The export produces a ZIP-file containing JSON-files, which can be used for inflator's content creation later."
+#: ./ftw/inflator/export/templates/export-form.pt:27
+msgid "export_warning"
+msgstr ""
+
+#: ./ftw/inflator/browser/inflate.pt:174
 msgid "ftw.inflator documentation"
 msgstr ""
+
+#. Default: "Warning:"
+#: ./ftw/inflator/export/templates/export-form.pt:27
+msgid "warning"
+msgstr ""
+
 

--- a/ftw/inflator/testing.py
+++ b/ftw/inflator/testing.py
@@ -1,15 +1,19 @@
-from Testing.ZopeTestCase.utils import setupCoreSessions
 from collective.transmogrifier import transmogrifier
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
 from ftw.inflator.patches import apply_patches
 from ftw.testing import ComponentRegistryLayer
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
+from ftw.testing.layer import TEMP_DIRECTORY
+from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
-from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import SITE_OWNER_NAME, SITE_OWNER_PASSWORD
-from plone.app.testing import applyProfile
 from plone.app.testing.layers import PloneFixture
 from plone.testing import z2
+from Testing.ZopeTestCase.utils import setupCoreSessions
 from zope.configuration import xmlconfig
 
 
@@ -100,7 +104,9 @@ ZOPE_FUNCTIONAL_TESTING = z2.FunctionalTesting(
 
 class InflatorLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (COMPONENT_REGISTRY_ISOLATION,
+                    BUILDER_LAYER,
+                    TEMP_DIRECTORY)
 
     def setUpZope(self, app, configurationContext):
         import Products.CMFPlacefulWorkflow
@@ -124,9 +130,18 @@ class InflatorLayer(PloneSandboxLayer):
         xmlconfig.file('configure.zcml', plone.app.dexterity,
                        context=configurationContext)
 
+        import ftw.jsondump
+        xmlconfig.file('configure.zcml', ftw.jsondump,
+                       context=configurationContext)
+
+        import ftw.zipexport
+        xmlconfig.file('configure.zcml', ftw.zipexport,
+                       context=configurationContext)
+
         setupCoreSessions(app)
 
     def setUpPloneSite(self, portal):
+        applyProfile(portal, 'ftw.inflator.export:default')
         applyProfile(
             portal, 'Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow')
 
@@ -139,4 +154,6 @@ INFLATOR_FIXTURE = InflatorLayer()
 INFLATOR_INTEGRATION_TESTING = IntegrationTesting(
     bases=(INFLATOR_FIXTURE, ), name="ftw.inflator:Integration")
 INFLATOR_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(INFLATOR_FIXTURE, ), name="ftw.inflator:Functional")
+    bases=(INFLATOR_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
+    name="ftw.inflator:Functional")

--- a/ftw/inflator/tests/test_export.py
+++ b/ftw/inflator/tests/test_export.py
@@ -1,0 +1,112 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.inflator.testing import INFLATOR_FUNCTIONAL_TESTING
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import plone
+from ftw.zipexport.zipfilestream import ZipFile
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from Products.CMFCore.utils import getToolByName
+from StringIO import StringIO
+from unittest2 import TestCase
+import json
+import transaction
+
+
+class TestExport(TestCase):
+    layer = INFLATOR_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        transaction.commit()
+
+    @browsing
+    def test_controlpanel_is_available(self, browser):
+        browser.login().open(view='overview-controlpanel')
+        browser.find('Inflator export').click()
+        self.assertEquals('inflator-export', plone.view())
+
+    @browsing
+    def test_export_of_objects(self, browser):
+        create(Builder('page').titled('The Page'))
+        folder = create(Builder('folder').titled('A Folder'))
+        create(Builder('page').titled('Another Page').within(folder))
+
+        browser.login().open(view='inflator-export')
+        browser.find('Export').click()
+        self.assertEquals('application/zip', browser.headers['content-type'])
+
+        zipfile = ZipFile(StringIO(browser.contents), 'r')
+        self.assertEquals(
+            ['content_creation/the-page.json',
+             'content_creation/a-folder.json'],
+            zipfile.namelist())
+
+    @browsing
+    def test_exporting_files(self, browser):
+        create(Builder('file').with_dummy_content().titled('The File'))
+        browser.login().open(view='inflator-export')
+        browser.find('Export').click()
+
+        zipfile = ZipFile(StringIO(browser.contents), 'r')
+        self.assertEquals(
+            ['content_creation/files/the-file-file/test.doc',
+             'content_creation/the-file.json'],
+            zipfile.namelist())
+
+        data = json.load(zipfile.open('content_creation/the-file.json'))
+        item, = data
+        self.assertDictContainsSubset(
+            {u'file:file': u'files/the-file-file/test.doc'}, item)
+
+    @browsing
+    def test_roundtrip(self, browser):
+        folder = create(Builder('folder').titled('A Folder'))
+
+        create(Builder('page').titled('First Page')
+               .within(folder)
+               .having(text='<p>Hello World</p>'))
+
+        create(Builder('file').titled('The File')
+               .attach_file_containing('print "Hello World"', 'helloworld.py')
+               .within(folder))
+
+        second_page = create(Builder('page').titled('Second Page')
+                             .having(text='<p>The Second Page</p>'))
+
+        browser.login().open(view='inflator-export')
+        browser.find('Export').click()
+        zipfile = ZipFile(StringIO(browser.contents), 'r')
+
+        self.portal.manage_delObjects([folder.getId(), second_page.getId()])
+
+        gsprofile = Builder('genericsetup profile')
+        for name in zipfile.namelist():
+            gsprofile.with_file(name, zipfile.open(name).read(), makedirs=True)
+
+        package = create(Builder('python package')
+                         .at_path(self.layer['temp_directory'])
+                         .named('my.package')
+                         .with_profile(gsprofile))
+
+        portal_setup = getToolByName(self.portal, 'portal_setup')
+        with package.zcml_loaded(self.layer['configurationContext']):
+            portal_setup.runAllImportStepsFromProfile(
+                'profile-my.package:default')
+
+        folder = self.portal.get('a-folder')
+        self.assertEquals('A Folder', folder.Title())
+
+        first_page = folder.get('first-page')
+        self.assertEquals('First Page', first_page.Title())
+        self.assertEquals('<p>Hello World</p>', first_page.getText())
+
+        the_file = folder.get('the-file')
+        self.assertEquals('The File', the_file.Title())
+        self.assertEquals('helloworld.py', the_file.getFile().filename)
+        self.assertEquals('print "Hello World"', the_file.getFile().data)
+
+        second_page = self.portal.get('second-page')
+        self.assertEquals('Second Page', second_page.Title())
+        self.assertEquals('<p>The Second Page</p>', second_page.getText())

--- a/setup.py
+++ b/setup.py
@@ -14,16 +14,24 @@ extras_require = {
     'multilingual': [
         'plone.app.multilingual',
         'plone.multilingualbehavior',  # both are required
+        ],
+
+    'export': [
+        'ftw.jsondump',
+        'ftw.zipexport',
         ]}
 
 
 extras_require['tests'] = tests_require = [
-    'unittest2',
-    'ftw.testing',
-    'zope.configuration',
-    'plone.testing',
-    'plone.app.testing',
     'Products.CMFPlacefulWorkflow',
+    'ftw.builder',
+    'ftw.testbrowser',
+    'ftw.testing',
+    'path.py',
+    'plone.app.testing',
+    'plone.testing',
+    'unittest2',
+    'zope.configuration',
     ] + reduce(list.__add__, extras_require.values())
 
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,3 +3,5 @@ extends = http://kgs.4teamwork.ch/sources.cfg
 extensions = mr.developer
 
 auto-checkout =
+# https://github.com/4teamwork/ftw.jsondump/pull/17
+    ftw.jsondump


### PR DESCRIPTION
:construction:  ~~https://github.com/4teamwork/ftw.jsondump/pull/17~~
The `ftw.inflator.export:default` profile adds an entry to the Plone control panel,
allowing to export the current content as ZIP with JSON-files.
The `content_creation` folder in the ZIP can be placed in a Generic Setup profile,
which will then create the content when installed.

The export may be incomplete, especially for types with additional features, such as
storing data in the annotations.
