### PR TITLE
Add transmogrifier config for creating single items.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -601,6 +601,23 @@ You can configure local roles and block local as following:
 For details, see: https://github.com/collective/collective.blueprint.jsonmigrator
 
 
+Import single items
+~~~~~~~~~~~~~~~~~~~
+
+The inflator's transmogrifier config can be used in code for importing
+single items by using the ``single_item_content_creation`` configuration:
+
+.. code:: python
+
+    item = {'_path': 'foo',
+            '_type': 'Folder',
+            'title': 'Foo'}
+
+    mogrifier = Transmogrifier(portal)
+    mogrifier(u'ftw.inflator.creation.single_item_content_creation',
+              jsonsource=dict(item=item))
+
+
 Links
 -----
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add transmogrifier config for creating single items.
+  [jone]
 
 
 1.5 (2015-04-22)

--- a/ftw/inflator/creation/configure.zcml
+++ b/ftw/inflator/creation/configure.zcml
@@ -34,6 +34,13 @@
         configuration="content_creation.cfg"
         />
 
+    <transmogrifier:registerConfig
+        name="ftw.inflator.creation.single_item_content_creation"
+        title="ftw.inflator: single item content creation"
+        description=""
+        configuration="single_item_content_creation.cfg"
+        />
+
 
     <!-- transmogrifier sections -->
     <utility

--- a/ftw/inflator/creation/configure.zcml
+++ b/ftw/inflator/creation/configure.zcml
@@ -42,6 +42,11 @@
         />
 
     <utility
+        name="ftw.inflator.creation.singleitemsource"
+        component=".sections.singleitemsource.SingleItemSource"
+        />
+
+    <utility
         name="ftw.inflator.multilingual.setup_languages"
         component=".sections.multilingual.SetupLanguages"
         />

--- a/ftw/inflator/creation/sections/jsonsource.py
+++ b/ftw/inflator/creation/sections/jsonsource.py
@@ -1,40 +1,11 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import resolvePackageReferenceOrFile
+from ftw.inflator.creation.sections.utils import recursive_encode
 from zope.interface import classProvides
 from zope.interface import implements
 import json
 import os.path
-
-
-def recursive_encode(data):
-    """Encodes unicodes (from json) to utf-8 strings recursively.
-    """
-    if isinstance(data, unicode):
-        return data.encode('utf-8')
-
-    elif isinstance(data, str):
-        return data
-
-    elif isinstance(data, dict):
-        for key, value in data.items():
-            del data[key]
-            data[recursive_encode(key)] = recursive_encode(value)
-        return data
-
-    elif isinstance(data, list):
-        new_data = []
-        for item in data:
-            new_data.append(recursive_encode(item))
-        return new_data
-
-    elif hasattr(data, '__iter__'):
-        for item in data:
-            recursive_encode(item)
-        return data
-
-    else:
-        return data
 
 
 class JSONSource(object):

--- a/ftw/inflator/creation/sections/singleitemsource.py
+++ b/ftw/inflator/creation/sections/singleitemsource.py
@@ -1,0 +1,20 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from ftw.inflator.creation.sections.utils import recursive_encode
+from zope.interface import classProvides
+from zope.interface import implements
+
+
+class SingleItemSource(object):
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.options = options
+
+    def __iter__(self):
+        for item in self.previous:
+            yield item
+
+        yield recursive_encode(self.options['item'])

--- a/ftw/inflator/creation/sections/utils.py
+++ b/ftw/inflator/creation/sections/utils.py
@@ -1,0 +1,29 @@
+
+def recursive_encode(data):
+    """Encodes unicodes (from json) to utf-8 strings recursively.
+    """
+    if isinstance(data, unicode):
+        return data.encode('utf-8')
+
+    elif isinstance(data, str):
+        return data
+
+    elif isinstance(data, dict):
+        for key, value in data.items():
+            del data[key]
+            data[recursive_encode(key)] = recursive_encode(value)
+        return data
+
+    elif isinstance(data, list):
+        new_data = []
+        for item in data:
+            new_data.append(recursive_encode(item))
+        return new_data
+
+    elif hasattr(data, '__iter__'):
+        for item in data:
+            recursive_encode(item)
+        return data
+
+    else:
+        return data

--- a/ftw/inflator/creation/single_item_content_creation.cfg
+++ b/ftw/inflator/creation/single_item_content_creation.cfg
@@ -1,0 +1,6 @@
+[transmogrifier]
+include = ftw.inflator.creation.content_creation_config
+
+[jsonsource]
+blueprint = ftw.inflator.creation.singleitemsource
+item = **will-be-replaced**

--- a/ftw/inflator/tests/test_section_jsonsource.py
+++ b/ftw/inflator/tests/test_section_jsonsource.py
@@ -8,52 +8,6 @@ import ftw.inflator.tests
 import os.path
 
 
-class TestRecursiveEncode(TestCase):
-
-    def equals(self, input, output):
-        self.assertEqual(jsonsource.recursive_encode(input), output)
-
-    def test_unicode(self):
-        self.equals(u'foo', 'foo')
-        self.equals(u'b\xe4r', 'b\xc3\xa4r')
-        self.equals('b\xc3\xa4r', 'b\xc3\xa4r')
-
-    def test_dicts(self):
-        self.equals({u'b\xe4r': u'b\xe4r'},
-                    {'b\xc3\xa4r': 'b\xc3\xa4r'})
-
-    def test_lists(self):
-        self.equals([u'b\xe4r'], ['b\xc3\xa4r'])
-
-    def test_other_types(self):
-        self.equals([1, 2.2, True, False, None],
-                    [1, 2.2, True, False, None])
-
-        self.equals(1, 1)
-        self.equals(None, None)
-
-    def test_nesting(self):
-        input = {
-            u'b\xe4r': {
-                u'b\xe4r': [
-                    u'b\xe4r',
-                    1,
-                    True]},
-            'blubb': [{
-                    u'b\xe4r': 3}]}
-
-        output = {
-            'b\xc3\xa4r': {
-                'b\xc3\xa4r': [
-                    'b\xc3\xa4r',
-                    1,
-                    True]},
-            'blubb': [{
-                    'b\xc3\xa4r': 3}]}
-
-        self.equals(input, output)
-
-
 class TestJSONSource(TestCase):
 
     def test_implements_interface(self):

--- a/ftw/inflator/tests/test_section_singleitemsource.py
+++ b/ftw/inflator/tests/test_section_singleitemsource.py
@@ -1,0 +1,29 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from ftw.inflator.creation.sections import singleitemsource
+from unittest2 import TestCase
+from zope.interface.verify import verifyClass
+from zope.interface.verify import verifyObject
+import ftw.inflator.tests
+import os.path
+
+
+class TestSingleItemSource(TestCase):
+
+    def test_implements_interface(self):
+        klass = singleitemsource.SingleItemSource
+
+        self.assertTrue(ISection.implementedBy(klass),
+                        'Class %s does not implement ISection.' % str(klass))
+        verifyClass(ISection, klass)
+
+        self.assertTrue(ISectionBlueprint.providedBy(klass),
+                        'Class %s does not provide ISectionBlueprint.' % (
+                str(klass)))
+        verifyObject(ISectionBlueprint, klass)
+
+    def test_yields_item_from_options(self):
+        source = singleitemsource.SingleItemSource(
+            None, '', {'item': {'foo': 'bar'}}, ())
+
+        self.assertEqual([{'foo': 'bar'}], list(source))

--- a/ftw/inflator/tests/test_section_utils.py
+++ b/ftw/inflator/tests/test_section_utils.py
@@ -1,0 +1,48 @@
+from ftw.inflator.creation.sections.utils import recursive_encode
+from unittest2 import TestCase
+
+
+class TestRecursiveEncode(TestCase):
+
+    def equals(self, input, output):
+        self.assertEqual(recursive_encode(input), output)
+
+    def test_unicode(self):
+        self.equals(u'foo', 'foo')
+        self.equals(u'b\xe4r', 'b\xc3\xa4r')
+        self.equals('b\xc3\xa4r', 'b\xc3\xa4r')
+
+    def test_dicts(self):
+        self.equals({u'b\xe4r': u'b\xe4r'},
+                    {'b\xc3\xa4r': 'b\xc3\xa4r'})
+
+    def test_lists(self):
+        self.equals([u'b\xe4r'], ['b\xc3\xa4r'])
+
+    def test_other_types(self):
+        self.equals([1, 2.2, True, False, None],
+                    [1, 2.2, True, False, None])
+
+        self.equals(1, 1)
+        self.equals(None, None)
+
+    def test_nesting(self):
+        input = {
+            u'b\xe4r': {
+                u'b\xe4r': [
+                    u'b\xe4r',
+                    1,
+                    True]},
+            'blubb': [{
+                    u'b\xe4r': 3}]}
+
+        output = {
+            'b\xc3\xa4r': {
+                'b\xc3\xa4r': [
+                    'b\xc3\xa4r',
+                    1,
+                    True]},
+            'blubb': [{
+                    'b\xc3\xa4r': 3}]}
+
+        self.equals(input, output)

--- a/ftw/inflator/tests/test_single_item_content_creation.py
+++ b/ftw/inflator/tests/test_single_item_content_creation.py
@@ -1,0 +1,22 @@
+from collective.transmogrifier.transmogrifier import Transmogrifier
+from ftw.inflator.testing import INFLATOR_INTEGRATION_TESTING
+from unittest2 import TestCase
+
+
+class TestSingleItemContentCreation(TestCase):
+    layer = INFLATOR_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_create_single_item(self):
+        item = {'_path': 'foo',
+                '_type': 'Folder',
+                'title': 'Foo'}
+
+        mogrifier = Transmogrifier(self.portal)
+        self.assertNotIn('foo', self.portal)
+        mogrifier(u'ftw.inflator.creation.single_item_content_creation',
+                  jsonsource=dict(item=item))
+        self.assertIn('foo', self.portal)
+        self.assertEquals('Foo', self.portal.foo.Title())


### PR DESCRIPTION
The inflator's transmogrifier config can be used in code for importing
single items by using the ``single_item_content_creation`` configuration:

```python
    item = {'_path': 'foo',
            '_type': 'Folder',
            'title': 'Foo'}

    mogrifier = Transmogrifier(portal)
    mogrifier(u'ftw.inflator.creation.single_item_content_creation',
              jsonsource=dict(item=item))
```