### PR TITLE
update imports for Plone 5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
+- Update imports for Plone 5
+  [erral]
+
 - Add transmogrifier config for creating single items.
   [jone]
 

--- a/ftw/inflator/creation/sections/multilingual.py
+++ b/ftw/inflator/creation/sections/multilingual.py
@@ -20,9 +20,9 @@ except pkg_resources.DistributionNotFound:
 else:
     HAS_MULTILINGUAL = True
     from plone.app.multilingual.browser.setup import SetupMultilingualSite
-    from plone.multilingual.interfaces import ILanguage
-    from plone.multilingual.interfaces import IMutableTG
-    from plone.multilingual.interfaces import ITranslationManager
+    from plone.app.multilingual.interfaces import IMutableTG
+    from plone.app.multilingual.interfaces import ITranslationManager
+    from Products.CMFPlone.interfaces import ILanguage
 
 
 class SetupLanguages(object):

--- a/ftw/inflator/tests/test_multilingual_content_creation.py
+++ b/ftw/inflator/tests/test_multilingual_content_creation.py
@@ -1,7 +1,7 @@
 from Products.CMFCore.utils import getToolByName
 from ftw.inflator.testing import INFLATOR_FUNCTIONAL_TESTING
 from plone.app.testing import applyProfile
-from plone.multilingual.interfaces import ITranslationManager
+from plone.app.multilingual.interfaces import ITranslationManager
 from unittest2 import TestCase
 
 


### PR DESCRIPTION
When using ftw.blueprints ftw.inflator is required, so I updated the imports to work in Plone 5 (see https://github.com/4teamwork/ftw.blueprints/pull/23)