### PR TITLE
Fix multilingual import error

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
+- Fix multilingual import error.
+  [elioschmutz]
+
 - Add transmogrifier config for creating single items.
   [jone]
 

--- a/ftw/inflator/creation/sections/multilingual.py
+++ b/ftw/inflator/creation/sections/multilingual.py
@@ -20,9 +20,9 @@ except pkg_resources.DistributionNotFound:
 else:
     HAS_MULTILINGUAL = True
     from plone.app.multilingual.browser.setup import SetupMultilingualSite
-    from plone.multilingual.interfaces import ILanguage
-    from plone.multilingual.interfaces import IMutableTG
-    from plone.multilingual.interfaces import ITranslationManager
+    from plone.app.multilingual.interfaces import ILanguage
+    from plone.app.multilingual.interfaces import IMutableTG
+    from plone.app.multilingual.interfaces import ITranslationManager
 
 
 class SetupLanguages(object):

--- a/ftw/inflator/creation/sections/multilingual.py
+++ b/ftw/inflator/creation/sections/multilingual.py
@@ -20,9 +20,16 @@ except pkg_resources.DistributionNotFound:
 else:
     HAS_MULTILINGUAL = True
     from plone.app.multilingual.browser.setup import SetupMultilingualSite
-    from plone.app.multilingual.interfaces import ILanguage
-    from plone.app.multilingual.interfaces import IMutableTG
-    from plone.app.multilingual.interfaces import ITranslationManager
+    try:
+        # plone.app.multilingual >= 2.x
+        from plone.app.multilingual.interfaces import ILanguage
+        from plone.app.multilingual.interfaces import IMutableTG
+        from plone.app.multilingual.interfaces import ITranslationManager
+    except:
+        # plone.app.multilingual 1.x
+        from plone.multilingual.interfaces import ILanguage
+        from plone.multilingual.interfaces import IMutableTG
+        from plone.multilingual.interfaces import ITranslationManager
 
 
 class SetupLanguages(object):


### PR DESCRIPTION
This fixes an importerror if using `plone.app.multilingual`.

The `plone.multilingual` is no longer used because it's merged into `plone.app.multilingual`.

See readme: https://github.com/plone/plone.multilingual

