### PR TITLE
Add portlets updater section, to allow the creation of portlets.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -528,6 +528,40 @@ Example:
       ]
 
 
+Portlets
+~~~~~~~~
+
+Portlets can easily be defined by using the ``_portlets`` key, expecting a dict (portlet_manager : configuration).
+It is possible to define the context portlets assignments (``assignments``) and set the inheritance settings (``blacklist_status``).
+
+.. code:: javascript
+
+      [
+          {
+              "_path": "foo",
+              "_type": "MyType",
+              "title": "Foo",
+              "_portlets": {
+                  "plone.leftcolumn": {
+                      "blacklist_status": {
+                          "context": "block",
+                          "user": "show",
+                          "group": "acquire"
+                      },
+                      "assignments": [
+                          {"id": "new_navigation",
+                          "portlet_type": "portlets.Navigation",
+                          "name": "New Navigation",
+                          "bottomLevel": 0,
+                          "includeTop": false,
+                          "topLevel": 1}
+                      ]
+                  }
+              }
+          }
+      ]
+
+
 UUID Lookup
 ~~~~~~~~~~~
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add portlets updater section, to allow the creation of portlets. [phgross]
 
 
 1.8.1 (2016-08-12)

--- a/ftw/inflator/creation/configure.zcml
+++ b/ftw/inflator/creation/configure.zcml
@@ -123,4 +123,9 @@
         component=".sections.resolvepath.ResolvePath"
         />
 
+    <utility
+        name="ftw.inflator.creation.portlets"
+        component=".sections.portlets.PortletUpdater"
+        />
+
 </configure>

--- a/ftw/inflator/creation/content_creation.cfg
+++ b/ftw/inflator/creation/content_creation.cfg
@@ -15,6 +15,7 @@ pipeline =
     workflowupdater
     placefulworkflowupdater
     propertiesupdater
+    portlets
     local_roles
     block_local_roles
     constraintypes
@@ -75,6 +76,9 @@ blueprint = plone.app.transmogrifier.workflowupdater
 
 [propertiesupdater]
 blueprint = ftw.inflator.creation.propertiesupdater
+
+[portlets]
+blueprint = ftw.inflator.creation.portlets
 
 [local_roles]
 blueprint = collective.blueprint.jsonmigrator.ac_local_roles

--- a/ftw/inflator/creation/sections/portlets.py
+++ b/ftw/inflator/creation/sections/portlets.py
@@ -1,0 +1,40 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from ftw.inflator.creation.sections.base import ObjectUpdater
+from plone.portlets.interfaces import IPortletAssignmentMapping
+from plone.portlets.interfaces import IPortletManager
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.component.interfaces import IFactory
+from zope.interface import classProvides
+from zope.interface import implements
+
+
+class PortletUpdater(ObjectUpdater):
+    """Add or replace portlets for a given context."""
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    key_option_name = 'portlets-key'
+    default_key_name = 'portlets'
+
+    def update(self, obj, data):
+        for key, conf in data.items():
+            manager = getUtility(IPortletManager, key)
+            mapping = getMultiAdapter(
+                (obj, manager), IPortletAssignmentMapping)
+
+            for portlet in conf.get('assignments', []):
+                self.create_assignment(portlet, mapping)
+
+            if conf.get('blacklist_status'):
+                self.set_blacklist(conf.get('blacklist_status'), obj, manager)
+
+    def create_assignment(self, properties, mapping):
+        portlet_id = properties.pop('id')
+        portlet_type = properties.pop('portlet_type')
+
+        portlet_factory = getUtility(IFactory, name=portlet_type)
+        assignment = portlet_factory(**properties)
+        mapping[portlet_id] = assignment

--- a/ftw/inflator/creation/sections/portlets.py
+++ b/ftw/inflator/creation/sections/portlets.py
@@ -1,6 +1,7 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from ftw.inflator.creation.sections.base import ObjectUpdater
+from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
 from zope.component import getMultiAdapter
@@ -38,3 +39,18 @@ class PortletUpdater(ObjectUpdater):
         portlet_factory = getUtility(IFactory, name=portlet_type)
         assignment = portlet_factory(**properties)
         mapping[portlet_id] = assignment
+
+    def set_blacklist(self, configuration, obj, manager):
+        assignable = getMultiAdapter((obj, manager),
+                                     ILocalPortletAssignmentManager)
+
+        for category, status in configuration.items():
+            if status.lower() == 'block':
+                assignable.setBlacklistStatus(category, True)
+            elif status.lower() == 'show':
+                assignable.setBlacklistStatus(category, False)
+            elif status.lower() == 'acquire':
+                assignable.setBlacklistStatus(category, None)
+            else:
+                raise ValueError(
+                    'Invalid blacklist status {!r}'.format(status))

--- a/ftw/inflator/tests/profiles/foo_creation/content_creation/01_folder_foo.json
+++ b/ftw/inflator/tests/profiles/foo_creation/content_creation/01_folder_foo.json
@@ -42,8 +42,25 @@
                         "baz": true}}
             }
 
-        ]
+        ],
 
+        "_portlets": {
+            "plone.leftcolumn": {
+                "blacklist_status": {
+                    "context": "block",
+                    "user": "show",
+                    "group": "acquire"
+                },
+                "assignments": [
+                    {"id": "new_navigation",
+                     "portlet_type": "portlets.Navigation",
+                     "name": "New Navigation",
+                     "bottomLevel": 0,
+                     "includeTop": false,
+                     "topLevel": 1}
+            ]
+          }
+        }
     }
 
 ]

--- a/ftw/inflator/tests/test_content_creation.py
+++ b/ftw/inflator/tests/test_content_creation.py
@@ -1,15 +1,19 @@
-from Products.ATContentTypes.lib import constraintypes
-from Products.CMFCore.utils import getToolByName
 from ftw.inflator.testing import INFLATOR_FIXTURE
 from ftw.inflator.tests.interfaces import IFoo
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
+from plone.app.testing import applyProfile
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
+from plone.portlets.interfaces import IPortletAssignmentMapping
+from plone.portlets.interfaces import IPortletManager
 from plone.uuid.interfaces import IUUID
+from Products.ATContentTypes.lib import constraintypes
+from Products.CMFCore.utils import getToolByName
 from unittest2 import TestCase
 from zope.annotation.interfaces import IAnnotations
+from zope.component import getMultiAdapter
+from zope.component import getUtility
 
 
 class FooCreationLayer(PloneSandboxLayer):
@@ -187,3 +191,16 @@ class TestContentCreation(TestCase):
 
         intranet = obj.get('intranet')
         self.assertFalse(hasattr(intranet, '__ac_local_roles_block__'))
+
+    def test_adding_portlets(self):
+        obj = self.portal.get('foo')
+        manager = getUtility(IPortletManager, 'plone.leftcolumn')
+        mapping = getMultiAdapter((obj, manager), IPortletAssignmentMapping)
+
+        self.assertEquals(1, len(mapping))
+
+        portlet = mapping.get('new_navigation')
+        self.assertEquals('New Navigation', portlet.name)
+        self.assertEquals(0, portlet.bottomLevel)
+        self.assertEquals(False, portlet.includeTop)
+        self.assertEquals(1, portlet.topLevel)

--- a/ftw/inflator/tests/test_content_creation.py
+++ b/ftw/inflator/tests/test_content_creation.py
@@ -5,6 +5,10 @@ from persistent.mapping import PersistentMapping
 from plone.app.testing import applyProfile
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
+from plone.portlets.constants import CONTEXT_CATEGORY
+from plone.portlets.constants import GROUP_CATEGORY
+from plone.portlets.constants import USER_CATEGORY
+from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
 from plone.uuid.interfaces import IUUID
@@ -204,3 +208,13 @@ class TestContentCreation(TestCase):
         self.assertEquals(0, portlet.bottomLevel)
         self.assertEquals(False, portlet.includeTop)
         self.assertEquals(1, portlet.topLevel)
+
+    def test_set_blacklists_correctly(self):
+        obj = self.portal.get('foo')
+        manager = getUtility(IPortletManager, 'plone.leftcolumn')
+        assignable = getMultiAdapter((obj, manager),
+                                     ILocalPortletAssignmentManager)
+
+        self.assertTrue(assignable.getBlacklistStatus(CONTEXT_CATEGORY))
+        self.assertFalse(assignable.getBlacklistStatus(USER_CATEGORY))
+        self.assertIsNone(assignable.getBlacklistStatus(GROUP_CATEGORY))


### PR DESCRIPTION
With the newly introduced PortletUpdater it's possible to define context portlets or adjust the portlet inheritance for a content directly inside the content json file.

More details see the [Readme](https://github.com/4teamwork/ftw.inflator/blob/pg_portlets_updater/README.rst#portlets )

