### PR TITLE
Fix Plone 4 support with plone.app.multilingual 2.x 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix Plone 4 support with plone.app.multilingual 2.x which should be the default for new Plone 4 projects. [elioschmutz]
 
 
 1.10.0 (2019-03-19)

--- a/ftw/inflator/__init__.py
+++ b/ftw/inflator/__init__.py
@@ -1,3 +1,4 @@
+from pkg_resources import DistributionNotFound
 from pkg_resources import get_distribution
 from zope.i18nmessageid import MessageFactory
 
@@ -6,3 +7,13 @@ _ = MessageFactory('ftw.inflator')
 
 
 IS_PLONE_5 = get_distribution('Plone').version >= '5'
+
+HAS_MULTILINGUAL = False
+IS_PLONE_APP_MULTILINGUAL_2 = False
+
+try:
+    dist = get_distribution('plone.app.multilingual')
+    IS_PLONE_APP_MULTILINGUAL_2 = '2' <= dist.version < '3'
+    HAS_MULTILINGUAL = True
+except DistributionNotFound:
+    pass

--- a/ftw/inflator/creation/sections/constraintypes.py
+++ b/ftw/inflator/creation/sections/constraintypes.py
@@ -1,11 +1,12 @@
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from ftw.inflator import IS_PLONE_5
+from ftw.inflator import IS_PLONE_APP_MULTILINGUAL_2
 from ftw.inflator.creation.sections.base import ObjectUpdater
 from Products.CMFPlone.utils import base_hasattr
 from zope.interface import classProvides
 
 
-if IS_PLONE_5:
+if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
     from plone.app.dexterity.behaviors import constrains as constraintypes
     from Products.CMFPlone.interfaces.constrains import ISelectableConstrainTypes
 else:
@@ -19,7 +20,7 @@ class ConstraintypesUpdater(ObjectUpdater):
     default_key_name = 'constrain_types'
 
     def update(self, obj, data):
-        if IS_PLONE_5:
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
             constrains = ISelectableConstrainTypes(obj)
             if constrains:
                 constrains.setConstrainTypesMode(constraintypes.ENABLED)

--- a/ftw/inflator/creation/sections/multilingual.py
+++ b/ftw/inflator/creation/sections/multilingual.py
@@ -1,7 +1,9 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from copy import deepcopy
+from ftw.inflator import HAS_MULTILINGUAL
 from ftw.inflator import IS_PLONE_5
+from ftw.inflator import IS_PLONE_APP_MULTILINGUAL_2
 from ftw.inflator.creation.sections.base import ObjectUpdater
 from ftw.inflator.exceptions import MultilingalInflateException
 from plone.uuid.interfaces import IUUIDGenerator
@@ -9,24 +11,18 @@ from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.interface import classProvides
 from zope.interface import implements
-import pkg_resources
 
 
-try:
-    pkg_resources.get_distribution('plone.app.multilingual')
-
-except pkg_resources.DistributionNotFound:
-    HAS_MULTILINGUAL = False
-
-else:
-    HAS_MULTILINGUAL = True
+if HAS_MULTILINGUAL:
     from plone.app.multilingual.browser.setup import SetupMultilingualSite
-    try:
-        # plone.app.multilingual >= 2.x
-        from Products.CMFPlone.interfaces import ILanguage
+    if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
+        if IS_PLONE_5:
+            from Products.CMFPlone.interfaces import ILanguage
+        else:
+            from plone.app.multilingual.interfaces import ILanguage
         from plone.app.multilingual.interfaces import IMutableTG
         from plone.app.multilingual.interfaces import ITranslationManager
-    except ImportError:
+    else:
         # plone.app.multilingual 1.x
         from plone.multilingual.interfaces import ILanguage
         from plone.multilingual.interfaces import IMutableTG

--- a/ftw/inflator/testing.py
+++ b/ftw/inflator/testing.py
@@ -1,4 +1,5 @@
 from collective.transmogrifier import transmogrifier
+from ftw.inflator import IS_PLONE_APP_MULTILINGUAL_2
 from ftw.inflator.patches import apply_patches
 from ftw.testing import ComponentRegistryLayer
 from ftw.testing import IS_PLONE_5
@@ -70,7 +71,6 @@ class ZopeLayer(PloneFixture):
             <include package="plonetheme.barceloneta" />
             </configure>''', context=configurationContext)
 
-
         z2.installProduct(app, 'Products.CMFPlacefulWorkflow')
 
         import Products.Five
@@ -119,6 +119,9 @@ class InflatorLayer(PloneSandboxLayer):
 
         z2.installProduct(app, 'Products.CMFPlacefulWorkflow')
 
+        if IS_PLONE_APP_MULTILINGUAL_2:
+            z2.installProduct(app, 'Products.DateRecurringIndex')
+
         import ftw.inflator
         xmlconfig.file('configure.zcml', ftw.inflator,
                        context=configurationContext)
@@ -145,7 +148,7 @@ class InflatorLayer(PloneSandboxLayer):
         setupCoreSessions(app)
 
     def setUpPloneSite(self, portal):
-        if IS_PLONE_5:
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
             applyProfile(portal, 'plone.app.contenttypes:default')
 
         applyProfile(

--- a/ftw/inflator/tests/test_content_creation.py
+++ b/ftw/inflator/tests/test_content_creation.py
@@ -1,3 +1,4 @@
+from ftw.inflator import IS_PLONE_APP_MULTILINGUAL_2
 from ftw.inflator.testing import INFLATOR_FIXTURE
 from ftw.inflator.tests.interfaces import IFoo
 from ftw.testing import IS_PLONE_5
@@ -24,7 +25,7 @@ from zope.component import getMultiAdapter
 from zope.component import getUtility
 
 
-if IS_PLONE_5:
+if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
     from plone.app.dexterity.behaviors import constrains as constraintypes
     from Products.CMFPlone.interfaces.constrains import ISelectableConstrainTypes
 else:
@@ -40,7 +41,7 @@ class FooCreationLayer(PloneSandboxLayer):
         wftool.setChainForPortalTypes(['Folder'],
                                       'simple_publication_workflow')
 
-        if IS_PLONE_5:
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
             folder_fti = portal.portal_types.Folder
             folder_fti.behaviors = tuple(
                 list(folder_fti.behaviors) + ['plone.constraintypes']
@@ -108,7 +109,7 @@ class TestContentCreation(TestCase):
     def test_foo_folder_constraintypes(self):
         foo = self.portal.get('foo')
 
-        if IS_PLONE_5:
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
             constrains = ISelectableConstrainTypes(foo)
             self.assertEqual(constrains.getConstrainTypesMode(),
                              constraintypes.ENABLED,
@@ -149,7 +150,7 @@ class TestContentCreation(TestCase):
         self.assertTrue(example_file)
         self.assertEqual(example_file.Title(), 'example file')
 
-        if IS_PLONE_5:
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
             data = example_file.file
             self.assertEqual(data.filename, 'examplefile.txt')
             self.assertEqual(data.contentType, 'text/plain')
@@ -207,22 +208,24 @@ class TestContentCreation(TestCase):
                         ' found under /foo/files/chuck-norris')
 
         self.assertEquals('Chuck Norris', chuck.Title())
-        self.assertTrue(chuck.getSize(), 'The chuck norris image seems to be missing')
 
-        if IS_PLONE_5:
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
+            self.assertTrue(chuck.image.getSize(),
+                            'The chuck norris image seems to be missing')
             self.assertEquals(chuck.image._width, 319)
             self.assertEquals(chuck.image._height, 397)
 
         else:
+            self.assertTrue(chuck.getSize(), 'The chuck norris image seems to be missing')
             self.assertEquals(chuck.getWidth(), 319)
             self.assertEquals(chuck.getHeight(), 397)
 
     def test_filename_can_be_changed(self):
         obj = self.portal.get('foo').get('files').get('filename-changed')
 
-        if IS_PLONE_5:
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
             self.assertEquals('filename-has-changed.jpg',
-                              obj.image.filename)            
+                              obj.image.filename)
         else:
             self.assertEquals('filename-has-changed.jpg',
                               obj.getImage().getFilename())
@@ -233,7 +236,7 @@ class TestContentCreation(TestCase):
 
         self.assertEquals('In other news', item.Title(), 'Wrong News Item title')
 
-        if IS_PLONE_5:
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
             self.assertTrue(item.text.raw, 'News item has no text')
         else:
             self.assertTrue(item.getText(), 'News item has no text')

--- a/ftw/inflator/tests/test_dx_content_creation.py
+++ b/ftw/inflator/tests/test_dx_content_creation.py
@@ -1,3 +1,4 @@
+from ftw.inflator import IS_PLONE_APP_MULTILINGUAL_2
 from ftw.inflator.testing import INFLATOR_FIXTURE
 from ftw.inflator.tests.interfaces import IFoo, IExampleDxType
 from ftw.testing import IS_PLONE_5
@@ -112,7 +113,7 @@ class TestDXContentCreation(TestCase):
         target = self.portal.get('target')
 
         # This behaves different with plone4 and referncablebehavior
-        if IS_PLONE_5:
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
             self.assertEqual(obj.relation.to_object, target)
         else:
             self.assertEqual(obj.relation, target)

--- a/ftw/inflator/tests/test_multilingual_content_creation.py
+++ b/ftw/inflator/tests/test_multilingual_content_creation.py
@@ -1,4 +1,5 @@
 from ftw.inflator import IS_PLONE_5
+from ftw.inflator import IS_PLONE_APP_MULTILINGUAL_2
 from ftw.inflator.testing import INFLATOR_FUNCTIONAL_TESTING
 from plone import api
 from plone.app.testing import applyProfile
@@ -6,9 +7,10 @@ from Products.CMFCore.utils import getToolByName
 from unittest2 import TestCase
 
 
-if IS_PLONE_5:
+if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
     from plone.app.multilingual.interfaces import ITranslationManager
 else:
+    # plone.app.multilingual 1.x
     from plone.multilingual.interfaces import ITranslationManager
 
 

--- a/test-plone-4.3.x-pml-1.cfg
+++ b/test-plone-4.3.x-pml-1.cfg
@@ -5,5 +5,5 @@ extends =
 
 package-name = ftw.inflator
 
-[versions]
-plone.app.multilingual = 2.0.4
+eggs +=
+    ftw.inflator[plone4_multilingual]


### PR DESCRIPTION
The PR https://github.com/4teamwork/ftw.inflator/pull/36 introduced an error with Plone 4 and `plone.app.multilingual` 2.x due the following commit: https://github.com/4teamwork/ftw.inflator/pull/36/commits/1257505003a37c216f630ab43ad698550cbd0632

According to the [plone.app.multilingual doucumentation](https://github.com/plone/plone.app.multilingual#versions), the V2.x should be used for plone4 with dexterity and real shared content.

The broken commit assumes, that using Plone 4 will require V1.x with `plone.app.multilingual`.

This PR fixes broken imports and functions if using it with `plone.app.multilingual` V2.x.