### PR TITLE
Implement custom root and language independent folder types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -365,6 +365,20 @@ language in the `portal_languages.xml`:
 
 The default setup of `plone.app.multilingual` is used for setting up the language folders.
 
+`plone.app.multilingual` is using a special portal type for the language root folders and for the language independent folders. Sometimes it is useful to have a custom portal type as root and language independent folders. You can choose custom types through the `_folder_type` and `_folder_type_language_independent` properties:
+
+
+.. code:: javascript
+
+    [
+        {"_multilingual": [
+            "en",
+            "de"],
+         "_folder_type": "my.custom.type",
+         "_folder_type_language_independent": "my.custom.type",
+         "_contents": []
+        }
+    ]
 
 
 Creating / setting properties

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Implement possibility to override the default plone.app.multilingual root and
+  language independent folder types. [elioschmutz]
 - Fix Plone 4 support with plone.app.multilingual 2.x which should be the default for new Plone 4 projects. [elioschmutz]
 
 

--- a/ftw/inflator/creation/sections/multilingual.py
+++ b/ftw/inflator/creation/sections/multilingual.py
@@ -54,6 +54,28 @@ class SetupLanguages(object):
         self._validate_languages(item['_multilingual'])
 
         multilingual_setup = SetupMultilingualSite()
+
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
+            if '_folder_type_language_independent' in item:
+                multilingual_setup.folder_type_language_independent = \
+                    item['_folder_type_language_independent']
+
+        if '_folder_type' in item:
+            multilingual_setup.folder_type = item['_folder_type']
+
+        if IS_PLONE_5:
+            # plone.app.multilingual 5.x is setting up the languagefolders
+            # automatically after installing the product.
+            # There is no possiblity to hook in this process. To be able to
+            # use our own types anyway, we remove the creted language-folders,
+            # and run our won setup with custom configuration.
+            #
+            # See https://github.com/plone/plone.app.multilingual/blob/5.2.x/src/plone/app/multilingual/setuphandlers.py#L33
+            catalog = getToolByName(self.context, 'portal_catalog')
+            for brain in catalog(portal_type="LRF"):
+                obj = brain.getObject()
+                obj.aq_parent.manage_delObjects([obj.getId()])
+
         multilingual_setup.setupSite(self.context)
 
         contents = deepcopy(item['_contents'])

--- a/ftw/inflator/tests/configure.zcml
+++ b/ftw/inflator/tests/configure.zcml
@@ -33,6 +33,22 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <genericsetup:registerProfile
+        name="dx_multilingual_custom_folder"
+        title="ftw.inflator.tests:dx_multilingual_custom_folder"
+        directory="profiles/dx_multilingual_custom_folder"
+        description=""
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        name="at_multilingual_custom_folder"
+        title="ftw.inflator.tests:at_multilingual_custom_folder"
+        directory="profiles/at_multilingual_custom_folder"
+        description=""
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
     <include package="ftw.inflator" file="meta.zcml" />
     <inflator:bundle
         title="ftw.inflator example bundle one"

--- a/ftw/inflator/tests/contents.py
+++ b/ftw/inflator/tests/contents.py
@@ -1,6 +1,11 @@
 from ftw.inflator.tests.interfaces import IExampleDxType
 from plone.dexterity.content import Item
+from plone.dexterity.content import Container
 from zope.interface import implements
+
+
+class ExampleDxContainerType(Container):
+    implements(IExampleDxType)
 
 
 class ExampleDxType(Item):

--- a/ftw/inflator/tests/profiles/at_multilingual_custom_folder/types.xml
+++ b/ftw/inflator/tests/profiles/at_multilingual_custom_folder/types.xml
@@ -1,0 +1,3 @@
+<object name="portal_types">
+    <object name="MultilingualCustomFolder" meta_type="Factory-based Type Information with dynamic views" />
+</object>

--- a/ftw/inflator/tests/profiles/at_multilingual_custom_folder/types/MultilingualCustomFolder.xml
+++ b/ftw/inflator/tests/profiles/at_multilingual_custom_folder/types/MultilingualCustomFolder.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<object name="MultilingualCustomFolder"
+   meta_type="Factory-based Type Information with dynamic views"
+   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="title" i18n:translate="">MultilingualCustomFolder</property>
+ <property name="description"
+     i18n:translate=""></property>
+ <property name="icon_expr"></property>
+ <property name="content_meta_type">ATFolder</property>
+ <property name="product">ATContentTypes</property>
+ <property name="factory">addATFolder</property>
+ <property name="immediate_view">folder_listing</property>
+ <property name="global_allow">True</property>
+ <property name="filter_content_types">False</property>
+ <property name="allowed_content_types"/>
+ <property name="allow_discussion">False</property>
+ <property name="default_view">folder_listing</property>
+ <property name="view_methods">
+  <element value="folder_summary_view"/>
+  <element value="folder_full_view"/>
+  <element value="folder_tabular_view"/>
+  <element value="atct_album_view"/>
+  <element value="folder_listing"/>
+ </property>
+ <alias from="(Default)" to="(dynamic view)"/>
+ <alias from="edit" to="atct_edit"/>
+ <alias from="sharing" to="@@sharing"/>
+ <alias from="view" to="(selected layout)"/>
+ <action title="View" action_id="view" category="object" condition_expr=""
+    url_expr="string:${folder_url}/" visible="True"
+    i18n:attributes="title">
+  <permission value="View"/>
+ </action>
+ <action title="Edit" action_id="edit" category="object" condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+    url_expr="string:${object_url}/edit" visible="True"
+    i18n:attributes="title">
+  <permission value="Modify portal content"/>
+ </action>
+ <action title="Folder Listing" action_id="folderlisting" category="folder"
+    condition_expr="object/isPrincipiaFolderish"
+    url_expr="string:${folder_url}/view" visible="False"
+    i18n:attributes="title">
+  <permission value="View"/>
+ </action>
+</object>

--- a/ftw/inflator/tests/profiles/dx_multilingual_custom_folder/types.xml
+++ b/ftw/inflator/tests/profiles/dx_multilingual_custom_folder/types.xml
@@ -1,0 +1,4 @@
+<object name="portal_types">
+    <object name="MultilingualCustomFolder" meta_type="Dexterity FTI" />
+    <object name="MultilingualIndependentCustomFolder" meta_type="Dexterity FTI" />
+</object>

--- a/ftw/inflator/tests/profiles/dx_multilingual_custom_folder/types/MultilingualCustomFolder.xml
+++ b/ftw/inflator/tests/profiles/dx_multilingual_custom_folder/types/MultilingualCustomFolder.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<object name="MultilingualCustomFolder"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.inflator.tests" >
+
+    <!-- Basic metadata -->
+    <property name="title">MultilingualCustomFolder</property>
+    <property name="global_allow">True</property>
+    <property name="add_permission">plone.app.contenttypes.addFolder</property>
+
+    <!-- schema interface -->
+    <property name="schema"></property>
+
+    <!-- class used for content items -->
+    <property name="klass">plone.app.contenttypes.content.Folder</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors" purge="false">
+        <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
+        <element value="plone.app.content.interfaces.INameFromTitle"/>
+        <element value="plone.app.dexterity.behaviors.discussion.IAllowDiscussion"/>
+        <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
+        <element value="Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes"/>
+        <element value="plone.app.relationfield.behavior.IRelatedItems"/>
+        <element value="plone.app.dexterity.behaviors.nextprevious.INextPreviousToggle"/>
+    </property>
+
+    <!-- View information -->
+    <property name="default_view">view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="view"/>
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(dynamic view)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="(selected layout)"/>
+
+    <!-- Actions -->
+    <action
+        action_id="view"
+        title="View"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}"
+        visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action
+        action_id="edit"
+        title="Edit"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}/edit"
+        visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/ftw/inflator/tests/profiles/dx_multilingual_custom_folder/types/MultilingualIndependentCustomFolder.xml
+++ b/ftw/inflator/tests/profiles/dx_multilingual_custom_folder/types/MultilingualIndependentCustomFolder.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<object name="MultilingualIndependentCustomFolder"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.inflator.tests" >
+
+    <!-- Basic metadata -->
+    <property name="title">MultilingualIndependentCustomFolder</property>
+    <property name="global_allow">True</property>
+    <property name="add_permission">plone.app.contenttypes.addFolder</property>
+
+    <!-- schema interface -->
+    <property name="schema"></property>
+
+    <!-- class used for content items -->
+    <property name="klass">plone.app.contenttypes.content.Folder</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors" purge="false">
+        <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
+        <element value="plone.app.content.interfaces.INameFromTitle"/>
+        <element value="plone.app.dexterity.behaviors.discussion.IAllowDiscussion"/>
+        <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
+        <element value="Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes"/>
+        <element value="plone.app.relationfield.behavior.IRelatedItems"/>
+        <element value="plone.app.dexterity.behaviors.nextprevious.INextPreviousToggle"/>
+    </property>
+
+    <!-- View information -->
+    <property name="default_view">view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="view"/>
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(dynamic view)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="(selected layout)"/>
+
+    <!-- Actions -->
+    <action
+        action_id="view"
+        title="View"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}"
+        visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action
+        action_id="edit"
+        title="Edit"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}/edit"
+        visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/ftw/inflator/tests/profiles/multilingual_creation/content_creation/content.json
+++ b/ftw/inflator/tests/profiles/multilingual_creation/content_creation/content.json
@@ -4,6 +4,8 @@
     "_properties": {
       "layout": ["string", "there"]
     },
+    "_folder_type": "MultilingualCustomFolder",
+    "_folder_type_language_independent": "MultilingualIndependentCustomFolder",
     "_contents": [
       {
         "_id:translate(ftw.inflator.tests)": "accessibility",

--- a/ftw/inflator/tests/test_multilingual_content_creation.py
+++ b/ftw/inflator/tests/test_multilingual_content_creation.py
@@ -36,6 +36,11 @@ class TestMultilingualContentCreation(TestCase):
             tool.addSupportedLanguage('de')
             tool.addSupportedLanguage('en')
 
+        if IS_PLONE_5 or IS_PLONE_APP_MULTILINGUAL_2:
+            applyProfile(self.portal, 'ftw.inflator.tests:dx_multilingual_custom_folder')
+        else:
+            applyProfile(self.portal, 'ftw.inflator.tests:at_multilingual_custom_folder')
+
         applyProfile(self.portal, 'plone.app.multilingual:default')
         applyProfile(self.portal, 'ftw.inflator.tests:multilingual_creation')
 
@@ -97,3 +102,16 @@ class TestMultilingualContentCreation(TestCase):
         import_step_name = 'ftw.inflator.content_creation'
         metadata = setup_tool.getImportStepMetadata(import_step_name)
         self.assertIn('languagetool', metadata.get('dependencies', ()))
+
+    def test_use_custom_multilingual_folders(self):
+        obj = self.portal.get('de')
+
+        self.assertEqual('MultilingualCustomFolder', obj.portal_type)
+
+        if IS_PLONE_5:
+            self.assertEqual('MultilingualIndependentCustomFolder',
+                             obj.restrictedTraverse('Assets').portal_type)
+
+        if IS_PLONE_APP_MULTILINGUAL_2:
+            self.assertEqual('MultilingualIndependentCustomFolder',
+                             obj.restrictedTraverse('media').portal_type)


### PR DESCRIPTION
This PR implements the possibility to change the default root and language independent folder types of `plone.app.multilingual`. 

- [V1.x](https://github.com/plone/plone.app.multilingual/blob/1.x/src/plone/app/multilingual/browser/setup.py#L31)
- [V2.x](https://github.com/plone/plone.app.multilingual/blob/2.0.4/src/plone/app/multilingual/browser/setup.py#L39)
- [V5.x](https://github.com/plone/plone.app.multilingual/blob/5.2.x/src/plone/app/multilingual/browser/setup.py#L42)