### PR TITLE
Replace discontinued collective.blueprint.jsonmigrator ...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -649,7 +649,7 @@ You can configure local roles and block local as following:
           }
       ]
 
-For details, see: https://github.com/collective/collective.blueprint.jsonmigrator
+For details, see: https://collectivejsonmigrator.readthedocs.io/en/latest/ac_local_roles.html
 
 
 Import single items

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Replace discontinued collective.blueprint.jsonmigrator with collective.jsonmigrator.
+ [djowett-ftw]
 
 
 1.11.0 (2019-06-13)

--- a/ftw/inflator/creation/configure.zcml
+++ b/ftw/inflator/creation/configure.zcml
@@ -8,7 +8,7 @@
 
     <include package="collective.transmogrifier" file="meta.zcml" />
     <include package="collective.transmogrifier" />
-    <include package="collective.blueprint.jsonmigrator" />
+    <include package="collective.jsonmigrator" />
     <include package="plone.app.transmogrifier" />
 
     <include

--- a/ftw/inflator/creation/content_creation.cfg
+++ b/ftw/inflator/creation/content_creation.cfg
@@ -81,7 +81,7 @@ blueprint = ftw.inflator.creation.propertiesupdater
 blueprint = ftw.inflator.creation.portlets
 
 [local_roles]
-blueprint = collective.blueprint.jsonmigrator.ac_local_roles
+blueprint = collective.jsonmigrator.local_roles
 
 [block_local_roles]
 blueprint = ftw.inflator.creation.block_local_roles

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(name='ftw.inflator',
 
           'plone.app.transmogrifier',
           'collective.transmogrifier',
-          'collective.blueprint.jsonmigrator',
+          'collective.jsonmigrator',
 
           'ftw.profilehook',
       ],


### PR DESCRIPTION
… with collective.jsonmigrator

Fixes https://github.com/4teamwork/izug.organisation/issues/1529

Are we Ok that collective.jsonmigrator comes with views that can  do mass migrations? I think so, given they are protected by cmf.ManagePortal permission, but just wanted to check