### PR TITLE
Fix Generic Setup import step registration.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.12.1 (unreleased)
 -------------------
 
+- Fix Generic Setup import step registration to not cause unresolved dependencies. [jone]
 - Fix tests for ftw.testing >= 2.0. [buchi]
 
 

--- a/ftw/inflator/creation/configure.zcml
+++ b/ftw/inflator/creation/configure.zcml
@@ -15,17 +15,27 @@
         zcml:condition="installed transmogrify.dexterity"
         package="transmogrify.dexterity" />
 
-
-    <genericsetup:importStep
-        name="ftw.inflator.content_creation"
-        title="ftw.inflator: content creation"
-        description="Generic content creation from content_creation/*.json files."
-        handler="ftw.inflator.creation.setuphandler.content_creation">
+    <configure zcml:condition="not-installed plone.app.multilingual">
+      <genericsetup:importStep
+          name="ftw.inflator.content_creation"
+          title="ftw.inflator: content creation"
+          description="Generic content creation from content_creation/*.json files."
+          handler="ftw.inflator.creation.setuphandler.content_creation">
         <depends name="typeinfo"/>
         <depends name="workflow"/>
-        <depends name="languagetool"
-                 zcml:condition="installed plone.app.multilingual"/>
-    </genericsetup:importStep>
+      </genericsetup:importStep>
+    </configure>
+    <configure zcml:condition="installed plone.app.multilingual">
+      <genericsetup:importStep
+          name="ftw.inflator.content_creation"
+          title="ftw.inflator: content creation"
+          description="Generic content creation from content_creation/*.json files."
+          handler="ftw.inflator.creation.setuphandler.content_creation">
+        <depends name="typeinfo"/>
+        <depends name="workflow"/>
+        <depends name="languagetool"/>
+      </genericsetup:importStep>
+    </configure>
 
     <transmogrifier:registerConfig
         name="ftw.inflator.creation.content_creation_config"

--- a/ftw/inflator/tests/test_multilingual_content_creation.py
+++ b/ftw/inflator/tests/test_multilingual_content_creation.py
@@ -101,7 +101,8 @@ class TestMultilingualContentCreation(TestCase):
         setup_tool = getToolByName(self.portal, 'portal_setup')
         import_step_name = 'ftw.inflator.content_creation'
         metadata = setup_tool.getImportStepMetadata(import_step_name)
-        self.assertIn('languagetool', metadata.get('dependencies', ()))
+        self.assertEqual({'languagetool', 'typeinfo', 'workflow'},
+                         set(metadata.get('dependencies', ())))
 
     def test_use_custom_multilingual_folders(self):
         obj = self.portal.get('de')


### PR DESCRIPTION
Problem:
```
WARNING GenericSetup There are unresolved or circular dependencies. Graphviz diagram:: digraph dependencies {...}
```
The content creation import steps should depend on `languagetool`, but only if `plone.app.multilingual` is installed. The condition did not work and cause this warning message.

Cause: the zcml-condition does not work on the <depends>-tag.
Solution: duplication of the import step registration section.