### PR TITLE
Remove old generic setup dependency for Products.PloneLanguageTool.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.12.1 (unreleased)
 -------------------
 
+- Remove old generic setup dependency for Products.PloneLanguageTool. [jone]
 - Fix tests for ftw.testing >= 2.0. [buchi]
 
 

--- a/ftw/inflator/creation/configure.zcml
+++ b/ftw/inflator/creation/configure.zcml
@@ -23,8 +23,6 @@
         handler="ftw.inflator.creation.setuphandler.content_creation">
         <depends name="typeinfo"/>
         <depends name="workflow"/>
-        <depends name="languagetool"
-                 zcml:condition="installed plone.app.multilingual"/>
     </genericsetup:importStep>
 
     <transmogrifier:registerConfig

--- a/ftw/inflator/tests/test_multilingual_content_creation.py
+++ b/ftw/inflator/tests/test_multilingual_content_creation.py
@@ -93,16 +93,6 @@ class TestMultilingualContentCreation(TestCase):
                           manager.get_translation('de'),
                           'English and German content should be linked.')
 
-    def test_content_creation_import_step_depends_on_languagetool(self):
-        # The content creation import step needs to depend on the
-        # "languagetool" import step when plone.app.multilingual is installed.
-        # The "languagetool" import step is not Plone core.
-
-        setup_tool = getToolByName(self.portal, 'portal_setup')
-        import_step_name = 'ftw.inflator.content_creation'
-        metadata = setup_tool.getImportStepMetadata(import_step_name)
-        self.assertIn('languagetool', metadata.get('dependencies', ()))
-
     def test_use_custom_multilingual_folders(self):
         obj = self.portal.get('de')
 


### PR DESCRIPTION
The content creation generic setup import step used to depend on the "languagetool" import step which is actually defined by Products.PloneLanguageTool (not by plone.app.multilingual).

Products.PloneLanguageTool is no longer state of the art as we use p.a.multilingual now.

Thus we do no longer need the misleading dependency which did not work correctly anyway (the condition cannot work like that).

Replaces #41 